### PR TITLE
Add default context aligned with the default controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The default type for context is empty object
 
 ## [0.3.0] - 2019-01-09
 ### Added

--- a/src/lib/crudella.ts
+++ b/src/lib/crudella.ts
@@ -3,7 +3,7 @@ import { createHandlers } from './service/handlers';
 import { createMiddlewareFactory } from './service/middleware';
 import { Definitions } from './settings/definitions';
 
-export const createService = <T extends { id: any }, C extends object>(defs: Definitions<T>) => {
+export const createService = <T extends { id: any }, C extends object = {}>(defs: Definitions<T>) => {
     const implementation = bootstrapConfiguration<T, C>(defs);
     const handlers = createHandlers(implementation);
     const createMiddleware = createMiddlewareFactory(handlers, implementation.controller);
@@ -15,7 +15,7 @@ export const createService = <T extends { id: any }, C extends object>(defs: Def
     };
 };
 
-export const buildService = <T extends { id: any }, C>(
+export const buildService = <T extends { id: any }, C = {}>(
     buildingDefs: Definitions<T, C>,
     prevDefs?: Definitions<T, C>
 ) => {


### PR DESCRIPTION
Add default value of context to type `{}` (empty object), which matches the default implementation of the controllers.